### PR TITLE
Add support for UTF-8 encoded data fields

### DIFF
--- a/lib/batch-apply-changes.js
+++ b/lib/batch-apply-changes.js
@@ -90,7 +90,7 @@ module.exports = (saveFileOverride) => {
                                 const value = chunkToHexVal(chunk);
                                 return { offset, value };
                             });
-                        } else if (['8utf8', '20utf8', '24utf8'].includes(entry.value)) {
+                        } else if (entry.value === 'utf8') {
                             // Reference: https://gist.github.com/ts-web/f045b69a975b0a6a00b9f4af8cdc1a14
                             var i8, i32, byte1, byte2, byte3, byte4, bits32;
 

--- a/lib/batch-apply-changes.js
+++ b/lib/batch-apply-changes.js
@@ -1,5 +1,6 @@
 module.exports = (saveFileOverride) => {
     const fs = require('fs');
+    const util = require('util');
     const arrayUtils = require('../util/array-utils.js');
     const saveFileUtils = require('../util/save-file-utils.js');
     const CONFIG = require('../config.json');
@@ -11,6 +12,7 @@ module.exports = (saveFileOverride) => {
     const saveFilename = 'game_data.sav';
     const saveFilepath = saveFileOverride || `${CONFIG.savepath}${saveFilename}`;
     const jsonEffectMapFile = `${CONFIG.mapfilepath}effectmap.json`;
+    const encoder = new util.TextEncoder();
 
     // options are currently: skipHardDependencies=true/false, skipSoftDependencies=true/false, withLogging=true/false
     const applyChanges = (effectMapFile, names, options) => {
@@ -87,6 +89,31 @@ module.exports = (saveFileOverride) => {
                                 const offset = entry.offset + i * 8;
                                 const value = chunkToHexVal(chunk);
                                 return { offset, value };
+                            });
+                        } else if (['8utf8', '20utf8', '24utf8'].includes(entry.value)) {
+                            // Reference: https://gist.github.com/ts-web/f045b69a975b0a6a00b9f4af8cdc1a14
+                            var i8, i32, byte1, byte2, byte3, byte4, bits32;
+
+                            let uint8 = encoder.encode(value);
+                            let uint32 = new Uint32Array(Math.ceil(uint8.length / 4.0));
+                            for (i8 = 0, i32 = 0; i8 <= uint8.length; i32++) {
+                                byte1 = uint8[i8++] || 0;
+                                byte2 = uint8[i8++] || 0;
+                                byte3 = uint8[i8++] || 0;
+                                byte4 = uint8[i8++] || 0;
+                                bits32 = 0 |
+                                    (byte1 << 25) |
+                                    (byte2 << 17) |
+                                    (byte3 << 9) |
+                                    byte4;
+                                uint32[i32] = bits32;
+                            }
+
+                            return uint32.map((val, i) => {
+                                return {
+                                    offset: entry.offset + i * 4,
+                                    value: val
+                                }
                             });
                         } else if (entry.value === 'integer') {
                             return {

--- a/lib/read-changes.js
+++ b/lib/read-changes.js
@@ -57,7 +57,7 @@ module.exports = (saveFileOverride) => {
                             }
                         })();
 
-                        const variableValuesExist = effect.entries.some(entry => ['float', 'integer', 'ascii', '8utf8', '20utf8', '24utf8'].includes(entry.value));
+                        const variableValuesExist = effect.entries.some(entry => ['float', 'integer', 'ascii', 'utf8'].includes(entry.value));
 
                         const entryGivesExpectedValue = (entry) => {
                             if (entry.value === true) {
@@ -75,9 +75,14 @@ module.exports = (saveFileOverride) => {
                                 value: effect.entries.map((entry) => {
                                     if (entry.value === 'ascii') {
                                         return readAsciiAtOffset(entry.offset, entry.length);
-                                    } else if (['8utf8', '20utf8', '24utf8'].includes(entry.value)) {
+                                    } else if (entry.value === 'utf8') {
                                         let rawstr = binary.read(entry.value, entry.offset);
-                                        return rawstr.substring(0, rawstr.indexOf('\u0000'));
+                                        let idx = rawstr.indexOf('\u0000');
+                                        if (idx >= 0) {
+                                            return rawstr.substring(0, idx);
+                                        } else {
+                                            return rawstr;
+                                        }
                                     } else if (entry.value === 'float') {
                                         return float32.decode(readAtOffset(entry.offset));
                                     } else {

--- a/lib/read-changes.js
+++ b/lib/read-changes.js
@@ -57,7 +57,7 @@ module.exports = (saveFileOverride) => {
                             }
                         })();
 
-                        const variableValuesExist = effect.entries.some(entry => entry.value === 'float' || entry.value === 'integer' || entry.value === 'ascii');
+                        const variableValuesExist = effect.entries.some(entry => ['float', 'integer', 'ascii', '8utf8', '20utf8', '24utf8'].includes(entry.value));
 
                         const entryGivesExpectedValue = (entry) => {
                             if (entry.value === true) {
@@ -75,6 +75,9 @@ module.exports = (saveFileOverride) => {
                                 value: effect.entries.map((entry) => {
                                     if (entry.value === 'ascii') {
                                         return readAsciiAtOffset(entry.offset, entry.length);
+                                    } else if (['8utf8', '20utf8', '24utf8'].includes(entry.value)) {
+                                        let rawstr = binary.read(entry.value, entry.offset);
+                                        return rawstr.substring(0, rawstr.indexOf('\u0000'));
                                     } else if (entry.value === 'float') {
                                         return float32.decode(readAtOffset(entry.offset));
                                     } else {

--- a/lib/read-changes.js
+++ b/lib/read-changes.js
@@ -7,7 +7,7 @@ module.exports = (saveFileOverride) => {
     const readline = require('readline-sync');
     const float32 = require('../encoders_decoders/float32.js');
     const asciiReader = require('./read-ascii-at-offset.js');
-    
+
     const saveFilename = 'game_data.sav';
     const saveFilepath = saveFileOverride || `${CONFIG.savepath}${saveFilename}`;
     const jsonEffectMapFile = `${CONFIG.mapfilepath}effectmap.json`;
@@ -76,18 +76,12 @@ module.exports = (saveFileOverride) => {
                                     if (entry.value === 'ascii') {
                                         return readAsciiAtOffset(entry.offset, entry.length);
                                     } else if (entry.value === 'utf8') {
-                                        let rawstr = binary.read(entry.value, entry.offset);
-                                        let idx = rawstr.indexOf('\u0000');
-                                        if (idx >= 0) {
-                                            return rawstr.substring(0, idx);
-                                        } else {
-                                            return rawstr;
-                                        }
+                                        return binary.read(["string0", entry.length, "utf-8"], entry.offset);
                                     } else if (entry.value === 'float') {
                                         return float32.decode(readAtOffset(entry.offset));
                                     } else {
                                         return readAtOffset(entry.offset)
-                                    } 
+                                    }
                                 })[0]
                             };
                             alreadyCheckedChanges[name] = result;

--- a/mapfiles/effectmap.json
+++ b/mapfiles/effectmap.json
@@ -2979,7 +2979,7 @@
           {
             "length": 8,
             "offset": 517696,
-            "value": "8utf8"
+            "value": "utf8"
           }
         ]
       },
@@ -3044,7 +3044,7 @@
           {
             "length": 8,
             "offset": 517824,
-            "value": "8utf8"
+            "value": "utf8"
           }
         ]
       },
@@ -3109,7 +3109,7 @@
           {
             "length": 8,
             "offset": 517952,
-            "value": "8utf8"
+            "value": "utf8"
           }
         ]
       },
@@ -3174,7 +3174,7 @@
           {
             "length": 8,
             "offset": 518080,
-            "value": "8utf8"
+            "value": "utf8"
           }
         ]
       },
@@ -3239,7 +3239,7 @@
           {
             "length": 8,
             "offset": 518208,
-            "value": "8utf8"
+            "value": "utf8"
           }
         ]
       },

--- a/mapfiles/effectmap.json
+++ b/mapfiles/effectmap.json
@@ -2979,7 +2979,7 @@
           {
             "length": 8,
             "offset": 517696,
-            "value": "ascii"
+            "value": "8utf8"
           }
         ]
       },
@@ -3044,7 +3044,7 @@
           {
             "length": 8,
             "offset": 517824,
-            "value": "ascii"
+            "value": "8utf8"
           }
         ]
       },
@@ -3109,7 +3109,7 @@
           {
             "length": 8,
             "offset": 517952,
-            "value": "ascii"
+            "value": "8utf8"
           }
         ]
       },
@@ -3174,7 +3174,7 @@
           {
             "length": 8,
             "offset": 518080,
-            "value": "ascii"
+            "value": "8utf8"
           }
         ]
       },
@@ -3239,7 +3239,7 @@
           {
             "length": 8,
             "offset": 518208,
-            "value": "ascii"
+            "value": "8utf8"
           }
         ]
       },

--- a/mapfiles/effectmap.json
+++ b/mapfiles/effectmap.json
@@ -2977,7 +2977,7 @@
       "name": {
         "entries": [
           {
-            "length": 8,
+            "length": 4,
             "offset": 517696,
             "value": "utf8"
           }
@@ -3042,7 +3042,7 @@
       "name": {
         "entries": [
           {
-            "length": 8,
+            "length": 4,
             "offset": 517824,
             "value": "utf8"
           }
@@ -3107,7 +3107,7 @@
       "name": {
         "entries": [
           {
-            "length": 8,
+            "length": 4,
             "offset": 517952,
             "value": "utf8"
           }
@@ -3172,7 +3172,7 @@
       "name": {
         "entries": [
           {
-            "length": 8,
+            "length": 4,
             "offset": 518080,
             "value": "utf8"
           }
@@ -3237,7 +3237,7 @@
       "name": {
         "entries": [
           {
-            "length": 8,
+            "length": 4,
             "offset": 518208,
             "value": "utf8"
           }

--- a/util/save-file-utils.js
+++ b/util/save-file-utils.js
@@ -160,9 +160,7 @@ module.exports = (() => {
 		    return pad + str;
 		},
 		typeSet: {
-		  '8utf8': ["string", 8, "utf-8"],
-		  '20utf8': ["string", 20, "utf-8"],
-		  '24utf8': ["string", 24, "utf-8"],
+		  'utf8': ["string", 24, "utf-8"],
 		  'word': ['array', 'uint32', 1]
 		}
 	};

--- a/util/save-file-utils.js
+++ b/util/save-file-utils.js
@@ -160,6 +160,9 @@ module.exports = (() => {
 		    return pad + str;
 		},
 		typeSet: {
+		  '8utf8': ["string", 8, "utf-8"],
+		  '20utf8': ["string", 20, "utf-8"],
+		  '24utf8': ["string", 24, "utf-8"],
 		  'word': ['array', 'uint32', 1]
 		}
 	};

--- a/util/save-file-utils.js
+++ b/util/save-file-utils.js
@@ -150,7 +150,7 @@ module.exports = (() => {
 
 		        return fs.writeFileSync(dest, buffer);
 		    };
-		    
+
 		    return funct(binary);
 		},
 		toHexString: (val) => {
@@ -160,7 +160,6 @@ module.exports = (() => {
 		    return pad + str;
 		},
 		typeSet: {
-		  'utf8': ["string", 24, "utf-8"],
 		  'word': ['array', 'uint32', 1]
 		}
 	};


### PR DESCRIPTION
Currently all fields are read and written assuming everything is encoding in ASCII, skipping one other byte when reading string fields. However, some users (like me!) name their horses with CJK characters which is not correctly handled by this tool (even not by other BotW save editor projects) so I added some necessary changes to correctly handle UTF-8 encoded characters.

I'm not familiar with JavaScript so everything is coded with reference to JS docs and googles. Correct me if there's any mistakes 😄 

exported `horses.slot2` information with wrong encoding(**original**):

```json
    "slot2": {
      "bond": 100,
      "color": 17,
      "mane": "Horse_Link_Mane_02",
      "name": "ã",
      "reins": "GameRomHorseReins_10",
      "saddle": "GameRomHorseSaddle_10",
      "type": "GameRomHorse15"
    },
    "slot3": {
      "bond": 100,
      "color": 1,
      "mane": "Horse_Link_Mane_04",
      "name": "ã¦",
      "reins": "GameRomHorseReins_02",
      "saddle": "GameRomHorseSaddle_10",
      "type": "GameRomHorse20"
    },
```

exported JSON **fixed**:

```json
    "slot2": {
      "bond": 100,
      "color": 17,
      "mane": "Horse_Link_Mane_02",
      "name": "い",
      "reins": "GameRomHorseReins_10",
      "saddle": "GameRomHorseSaddle_10",
      "type": "GameRomHorse15"
    },
    "slot3": {
      "bond": 100,
      "color": 1,
      "mane": "Horse_Link_Mane_04",
      "name": "て",
      "reins": "GameRomHorseReins_02",
      "saddle": "GameRomHorseSaddle_10",
      "type": "GameRomHorse20"
    },
```